### PR TITLE
Removed .snyk exception file as the only exception in it (jq) is no l…

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-LINUX-JQ-105334:
-    - '*':
-        reason: removed, ticket raised for project remediation (DW-3148)
-        expires: 2020-01-20T00:00:00.000Z
-patch: {}


### PR DESCRIPTION
…onger flagging since alpine bump. Worth being aware that Snyk reports it does not currently scan alpine:3.11.2