### PR TITLE
Added awscli, and assume-role capabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PYTHON-PYYAML-590151:
+    - '*':
+        reason: Latest version of AWS CLI, no fix.
+        expires: 2030-06-24T00:00:00.000Z
+patch: {}

--- a/assume-role
+++ b/assume-role
@@ -1,0 +1,7 @@
+set +x
+DURATION=${ASSUME_DURATION:=900}
+AWS_STS=$(aws sts assume-role --role-arn ${AWS_ROLE_ARN} --role-session-name awscli-$(date +%m%d%y%H%M%S) --duration-seconds ${DURATION})
+export AWS_SECRET_ACCESS_KEY=$(echo $AWS_STS | jq .Credentials.SecretAccessKey -r)
+export AWS_ACCESS_KEY_ID=$(echo $AWS_STS | jq .Credentials.AccessKeyId -r)
+export AWS_SESSION_TOKEN=$(echo $AWS_STS | jq .Credentials.SessionToken -r)
+set -x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+awscli >= 1.18.0
 boto3 >= 1.9.160,<2.0.0
 behave >= 1.2.6,<2.0.0
 pycryptodome >= 3.8.1


### PR DESCRIPTION
In order to support the migration to AWS Concourse, we need to add the AWS CLI and the `assume-role` function to this image.